### PR TITLE
Remove links to unused social media platforms

### DIFF
--- a/templates/status.json
+++ b/templates/status.json
@@ -11,10 +11,6 @@
     "contact": {
         "phone": "+4995118505145",
         "irc": "irc://freenode/#backspace",
-        "facebook": "https://www.facebook.com/hackerspace.bamberg",
-        "google": {
-            "plus": "https://plus.google.com/116003874054937500169"
-        },
         "twitter": "@b4ckspace",
         "email": "info@hackerspace-bamberg.de",
         "ml": "public@lists.hackerspace-bamberg.de"

--- a/testdata/status.json
+++ b/testdata/status.json
@@ -11,10 +11,6 @@
     "contact": {
         "phone": "+4995118505145",
         "irc": "irc://freenode/#backspace",
-        "facebook": "https://www.facebook.com/hackerspace.bamberg",
-        "google": {
-            "plus": "https://plus.google.com/116003874054937500169"
-        },
         "twitter": "@b4ckspace",
         "email": "info@hackerspace-bamberg.de",
         "ml": "public@lists.hackerspace-bamberg.de"


### PR DESCRIPTION
Remove links to Facebook and Google+ websites as they are no longer used or don't exist anymore.